### PR TITLE
Adjust buttons of camera page and add Upload button

### DIFF
--- a/login.kv
+++ b/login.kv
@@ -1179,23 +1179,29 @@
         id: camera
         resolution: (640, 480)
         play: False
-    ToggleButton:
+    ToggleButton:   
         text: 'PLAY'
         on_press: camera.play = not camera.play
-        pos_hint: {"center_x": 0.5, "center_y": 0.4}
+        pos_hint: {"center_x": 0.5, "center_y": 0.25}
         size_hint_y: None
-        height: '48dp'
+        height: '28dp'
     Button:
         text: 'CAPTURE'
         size_hint_y: None
-        pos_hint: {"center_x": 0.5, "center_y": 0.3}
-        height: '48dp'
+        pos_hint: {"center_x": 0.5, "center_y": 0.19}
+        height: '28dp'
         on_press: app.capture()
+    Button:
+        text: 'UPLOAD'
+        size_hint_y: None
+        pos_hint: {"center_x": 0.5, "center_y": 0.13}
+        height: '28dp'
+
     Button:
         text: 'PREDICT'
         size_hint_y: None
-        pos_hint: {"center_x": 0.5, "center_y": 0.2}
-        height: '48dp'
+        pos_hint: {"center_x": 0.5, "center_y": 0.07}
+        height: '28dp'
         on_press: root.manager.current = "eleventh_page"   
     
     


### PR DESCRIPTION
## Related issue
- The camera page has the play and capture buttons overlapping the camera screen. #8

## Description
- I have resized the buttons of the camera page and have changed their positions so that they don't overlap on the camera screen.
- I have also added an Upload button.

## Screenshot
![WhatsApp Image 2022-07-29 at 3 24 54 PM](https://user-images.githubusercontent.com/75883328/181734600-a9f8fa56-cbdb-4405-a0ba-cb7f01b15fec.jpeg)
